### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+* @The-Mycelium-Network/tmn-review-team


### PR DESCRIPTION
Add a `CODEOWNERS` file to complete the puzzle of auto-assignment on pull requests. See the issue for more details.

fix #28